### PR TITLE
add  percent and em units to slider

### DIFF
--- a/src/component/Selectors/WidthAndHeight.tsx
+++ b/src/component/Selectors/WidthAndHeight.tsx
@@ -5,7 +5,7 @@ import { Text } from "../Styled"
 import useStyleValue from "../../hooks/useStyleValue"
 import useApplyStyle from "../../hooks/useApplyStyle"
 import { getUnit, getNumbericValue as getValue } from "../../helper"
-const units = ["px", "rem"]
+const units = ["px", "rem", "%", "em"]
 
 const WidthAndHeight = () => {
     const applyStyle = useApplyStyle()
@@ -31,7 +31,7 @@ const WidthAndHeight = () => {
                 <div className={style.body}>
                     <Slider
                         min={0}
-                        max={500}
+                        max={widthUnit === "%" ? 100 : (widthUnit === "em" ? 50 : 500)}
                         value={widthValue}
                         onChange={(value) => {
                             applyStyle("width", value + widthUnit)
@@ -53,7 +53,7 @@ const WidthAndHeight = () => {
                 <div className={style.body}>
                     <Slider
                         min={0}
-                        max={500}
+                        max={heightUnit === "%" ? 100 : (heightUnit === "em" ? 50 : 500)}
                         value={heightValue}
                         onChange={(value) => {
                             applyStyle("height", value + heightUnit)

--- a/src/welcome-map.tsx
+++ b/src/welcome-map.tsx
@@ -8,6 +8,7 @@ const map: ComponentMember[] = [
             className: "container",
             style: {
                 width: "500px",
+                height: "400px",
                 background: "rgba(255, 255, 255, 1)",
                 borderRadius: "64px",
                 boxShadow: "2px 2px 43px 0px #999999",


### PR DESCRIPTION
In this change by increasing the number of units from 2 to 4 for slider, user can have different styles easily and can use new units based on the code that they want.